### PR TITLE
fixed deprecated base/Time header

### DIFF
--- a/src/CtdTypes.hpp
+++ b/src/CtdTypes.hpp
@@ -8,7 +8,7 @@
 #ifndef CTD_SEABIRD_CTDTYPES_HPP
 #define CTD_SEABIRD_CTDTYPES_HPP
 
-#include <base/time.h>
+#include <base/Time.hpp>
 
 namespace ctd_seabird {
     // namespace ctd_seabird


### PR DESCRIPTION
Don't know if this package is still in use or maintained. Nonetheless fixed the time headers.
